### PR TITLE
Drop org.kde.* own-name

### DIFF
--- a/app.lith.Lith.json
+++ b/app.lith.Lith.json
@@ -15,7 +15,6 @@
         "--talk-name=com.canonical.indicator.application",
         "--talk-name=org.ayatana.indicator.application",
         "--talk-name=org.freedesktop.portal.Fcitx",
-        "--own-name=org.kde.*",
         "--talk-name=org.freedesktop.secrets"
     ],
     "cleanup": [


### PR DESCRIPTION
This is no longer required with any supported runtimes, the issue was fixed in Qt

https://docs.flatpak.org/en/latest/desktop-integration.html#statusnotifier

> Most implementations of StatusNotifer have dropped this requirement

https://github.com/flathub/flatpak-builder-lint/issues/66#issuecomment-1386033025